### PR TITLE
Switch to new blob-storage storage layout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/.idea
 .ropeproject
 node_modules
 bower_components

--- a/ckanext/datapub/templates/datapub/snippets/upload_module.html
+++ b/ckanext/datapub/templates/datapub/snippets/upload_module.html
@@ -5,10 +5,10 @@
 {% resource 'datapub/js/main.c4752953.chunk.js' %}
 
 <div id="ResourceEditor"
-     data-dataset-id="{{ pkg_name }}"
+     data-dataset-id="{{ pkg_id }}"
      data-api="{{ base_url }}"
-     data-lfs="{{ h.extstorage_lfs_url() }}"
+     data-lfs="{{ h.extstorage_server_url() }}"
      data-auth-token="{{ api_key }}"
-     data-organization-id="{{ h.extstorage_organization_name(pkg_name) }}"
+     data-organization-id="{{ h.extstorage_storage_namespace() }}"
      data-resource-id="{{ resource_id }}">
 </div>

--- a/ckanext/datapub/templates/datapub/snippets/upload_module.template
+++ b/ckanext/datapub/templates/datapub/snippets/upload_module.template
@@ -1,10 +1,10 @@
 {{RESOURCES}}
 
 <div id="ResourceEditor"
-     data-dataset-id="{{ pkg_name }}"
+     data-dataset-id="{{ pkg_id }}"
      data-api="{{ base_url }}"
-     data-lfs="{{ h.extstorage_lfs_url() }}"
+     data-lfs="{{ h.extstorage_server_url() }}"
      data-auth-token="{{ api_key }}"
-     data-organization-id="{{ h.extstorage_organization_name(pkg_name) }}"
+     data-organization-id="{{ h.extstorage_storage_namespace() }}"
      data-resource-id="{{ resource_id }}">
 </div>

--- a/ckanext/datapub/templates/package/new_resource.html
+++ b/ckanext/datapub/templates/package/new_resource.html
@@ -1,5 +1,7 @@
 {% ckan_extends %}
 
+{% set package_id = pkg_dict.id %}
+
 {% block form %}
-  {% snippet 'datapub/snippets/upload_module.html', pkg_name=pkg_name, api_key=c.userobj.apikey, base_url=g.site_url, parent=super %}
+  {% snippet 'datapub/snippets/upload_module.html', pkg_id=package_id, api_key=c.userobj.apikey, base_url=g.site_url, parent=super %}
 {% endblock %}

--- a/ckanext/datapub/templates/package/new_resource_not_draft.html
+++ b/ckanext/datapub/templates/package/new_resource_not_draft.html
@@ -1,5 +1,7 @@
 {% ckan_extends %}
 
+{% set package_id = pkg_dict.id %}
+
 {% block form %}
-  {% snippet 'datapub/snippets/upload_module.html', pkg_name=pkg_name, api_key=c.userobj.apikey, base_url=g.site_url, parent=super %}
+  {% snippet 'datapub/snippets/upload_module.html', pkg_id=package_id, api_key=c.userobj.apikey, base_url=g.site_url, parent=super %}
 {% endblock %}

--- a/ckanext/datapub/templates/package/resource_edit.html
+++ b/ckanext/datapub/templates/package/resource_edit.html
@@ -1,5 +1,5 @@
 {% ckan_extends %}
 
 {% block form %}
-  {% snippet 'datapub/snippets/upload_module.html', resource_id=res.id, pkg_name=pkg.name, parent=super %}
+  {% snippet 'datapub/snippets/upload_module.html', resource_id=res.id, pkg_id=pkg.id, parent=super %}
 {% endblock %}


### PR DESCRIPTION
This is done in order to support https://github.com/datopian/ckanext-blob-storage/pull/49 and will not be compatible with existing versions of ckanext-blob-storage, so it needs to be merged / deployed together. 

See also #8 which we may want to fix before merging this.