### PR TITLE
Support for CKAN 2.9

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,5 @@
 include README.md
 include LICENSE
 include requirements.txt
-recursive-include ckanext/datapub *.html *.json *.js *.less *.css *.mo
+recursive-include ckanext/datapub/templates *
+recursive-include ckanext/datapub/fanstatic *

--- a/README.md
+++ b/README.md
@@ -39,12 +39,12 @@ It would:
 
 CKAN >= 2.9 uses webassets to manage all the bundles and the tag changed from `resource` to `asset`.
 
-In order to build an `upload_module.html` that runs on CKAN >= 2.9 you can pass `webasset` as third parameter.
+In order to build an `upload_module.html` that runs on CKAN >= 2.9 you can pass `webassets` as third parameter.
 
 Example:
 
 ```
-sh sync.sh https://github.com/datopian/datapub master webasset
+sh sync.sh https://github.com/datopian/datapub master webassets
 ```
 
 This will create an `upload_module.html` like the following one:

--- a/README.md
+++ b/README.md
@@ -35,3 +35,30 @@ It would:
      data-resource-id="{{ resource_id }}">
 </div>
 ```
+## CKAN >= 2.9 support
+
+CKAN >= 2.9 uses webassets to manage all the bundles and the tag changed from `resource` to `asset`.
+
+In order to build an `upload_module.html` that runs on CKAN >= 2.9 you can pass `webasset` as third parameter.
+
+Example:
+
+```
+sh sync.sh https://github.com/datopian/datapub master webasset
+```
+
+This will create an `upload_module.html` like the following one:
+
+```html
+{% asset "datapub/datapub-js" %}
+{% asset "datapub/datapub-css" %}
+
+<div id="ResourceEditor"
+     data-dataset-id="{{ pkg_name }}"
+     data-api="{{ base_url }}"
+     data-lfs="{{ h.blob_storage_lfs_url() }}"
+     data-auth-token="{{ api_key }}"
+     data-organization-id="{{ h.blob_storage_organization_name(pkg_name) }}"
+     data-resource-id="{{ resource_id }}">
+</div>
+```

--- a/ckanext/datapub/fanstatic/webassets.yml
+++ b/ckanext/datapub/fanstatic/webassets.yml
@@ -1,8 +1,8 @@
 datapub-css:
  output: datapub/main.css
  contents:
- - css/*.css
+ - css/*.*.*.css
 datapub-js:
  output: datapub/main.js
  contents:
- - js/*.js
+ - js/*.*.*.js

--- a/ckanext/datapub/fanstatic/webassets.yml
+++ b/ckanext/datapub/fanstatic/webassets.yml
@@ -1,7 +1,8 @@
-datapub-js:
-  contents:
-    - js/*
-
 datapub-css:
-  contents:
-    - css/*
+ output: datapub/main.css
+ contents:
+ - css/*.css
+datapub-js:
+ output: datapub/main.js
+ contents:
+ - js/*.js

--- a/ckanext/datapub/fanstatic/webassets.yml
+++ b/ckanext/datapub/fanstatic/webassets.yml
@@ -6,3 +6,4 @@ datapub-js:
  output: datapub/main.js
  contents:
  - js/*.*.*.js
+ - js/*.*.js

--- a/ckanext/datapub/fanstatic/webassets.yml
+++ b/ckanext/datapub/fanstatic/webassets.yml
@@ -1,0 +1,7 @@
+datapub-js:
+  contents:
+    - js/*
+
+datapub-css:
+  contents:
+    - css/*

--- a/sync.sh
+++ b/sync.sh
@@ -2,7 +2,7 @@
 
 DATAPUB_APP=${1-'https://github.com/datopian/datapub'}
 DATAPUB_VERSION=${2-'master'}
-TAG=${3-'resource'}
+TAG=${3-'resources'}
 UPLOAD_MODULE_PATH=ckanext/datapub/templates/blob_storage/snippets/upload_module
 
 git clone --branch $DATAPUB_VERSION $DATAPUB_APP datapub
@@ -11,7 +11,7 @@ wget https://raw.githubusercontent.com/johanhaleby/bash-templater/master/templat
 cd datapub
 npm install . && npm run build
 
-if [ $TAG = 'webasset' ]
+if [ $TAG = 'webassets' ]
 then
   echo "Creating asset tags"
   assets="datapub/datapub-js datapub/datapub-css"

--- a/sync.sh
+++ b/sync.sh
@@ -9,7 +9,7 @@ git clone --branch $DATAPUB_VERSION $DATAPUB_APP datapub
 wget https://raw.githubusercontent.com/johanhaleby/bash-templater/master/templater.sh
 
 cd datapub
-npm install . && npm run build:ckan
+npm install . && npm run build
 
 if [ $TAG = 'webasset' ]
 then

--- a/sync.sh
+++ b/sync.sh
@@ -2,6 +2,7 @@
 
 DATAPUB_APP=${1:='https://github.com/datopian/datapub'}
 DATAPUB_VERSION=${2:='master'}
+TAG=${3:='resource'}
 UPLOAD_MODULE_PATH=ckanext/datapub/templates/blob_storage/snippets/upload_module
 
 git clone --branch $DATAPUB_VERSION $DATAPUB_APP datapub
@@ -9,9 +10,18 @@ wget https://raw.githubusercontent.com/johanhaleby/bash-templater/master/templat
 
 cd datapub
 npm install . && npm run build
-for x in $(ls build/static/js/*.js build/static/css/*.css); do
-  bundles=$bundles"\{\% resource \"${x}\" \%\}"\\n
-done
+
+if [ $TAG = 'webasset' ]
+then
+  for x in "datapub/datapub-js datapub/datapub-css"; do
+    bundles=$bundles"\{\% asset \"${x}\" \%\}"\\n
+  done
+else
+  for x in $(ls build/static/js/*.js build/static/css/*.css); do
+    bundles=$bundles"\{\% resource \"${x}\" \%\}"\\n
+  done
+fi
+
 cp -r build/static/* ../ckanext/datapub/fanstatic/
 cd ..
 

--- a/sync.sh
+++ b/sync.sh
@@ -1,22 +1,25 @@
 #!/bin/bash
 
-DATAPUB_APP=${1:='https://github.com/datopian/datapub'}
-DATAPUB_VERSION=${2:='master'}
-TAG=${3:='resource'}
+DATAPUB_APP=${1-'https://github.com/datopian/datapub'}
+DATAPUB_VERSION=${2-'master'}
+TAG=${3-'resource'}
 UPLOAD_MODULE_PATH=ckanext/datapub/templates/blob_storage/snippets/upload_module
 
 git clone --branch $DATAPUB_VERSION $DATAPUB_APP datapub
 wget https://raw.githubusercontent.com/johanhaleby/bash-templater/master/templater.sh
 
 cd datapub
-npm install . && npm run build
+npm install . && npm run build:ckan
 
 if [ $TAG = 'webasset' ]
 then
-  for x in "datapub/datapub-js datapub/datapub-css"; do
+  echo "Creating asset tags"
+  assets="datapub/datapub-js datapub/datapub-css"
+  for x in $assets; do
     bundles=$bundles"\{\% asset \"${x}\" \%\}"\\n
   done
 else
+  echo "Creating resource tags"
   for x in $(ls build/static/js/*.js build/static/css/*.css); do
     bundles=$bundles"\{\% resource \"${x}\" \%\}"\\n
   done


### PR DESCRIPTION
CKAN >= 2.9 uses webassets to manage all the bundles and the tag changed from `resource` to `asset`.

Changes:
- An optional third parameter when doing the setup of the JS module to write down webasset tags instead of resources.
- A default `webasset.yml` file (Mandatory in CKAN >= 2.9)
- A how to use section in the docs
- Changes in the MANIFEST.in to include `webasset.yml` file when installing from source

This changes are backwards compatible, people executing: `sh sync.sh` will still set up for CKAN 2.8 
